### PR TITLE
fix on error management

### DIFF
--- a/src/redux/middlewares/noteMiddlewares.jsx
+++ b/src/redux/middlewares/noteMiddlewares.jsx
@@ -8,13 +8,13 @@ const getNote = ({ noteId, notepadId }) => async (dispatch) => {
     const response = await noteAPI.getNote({ noteId, notepadId });
     const body = await response.json();
 
-    if (!response.ok) { throw new Error(body.error); }
+    if (!response.ok) { throw new Error(body); }
 
     dispatch(updateCurrentNote({ title: body.title, content: body.content }));
     dispatch(requestSuccess());
     return true;
-  } catch (errorMessage) {
-    dispatch(requestFailure(errorMessage));
+  } catch (error) {
+    dispatch(requestFailure(error.message));
     return false;
   }
 };
@@ -25,13 +25,13 @@ const createNote = ({ notepadId, title, content }) => async (dispatch) => {
     const response = await noteAPI.createNote({ notepadId, title, content });
     const body = await response.json();
 
-    if (!response.ok) { throw new Error(body.error); }
+    if (!response.ok) { throw new Error(body); }
 
     dispatch(updateCurrentNote({ title: body.title, content: body.content }));
     dispatch(requestSuccess());
     return true;
-  } catch (errorMessage) {
-    dispatch(requestFailure(errorMessage));
+  } catch (error) {
+    dispatch(requestFailure(error.message));
     return false;
   }
 };
@@ -46,13 +46,13 @@ const updateNote = ({
     });
     const body = await response.json();
 
-    if (!response.ok) { throw new Error(body.error); }
+    if (!response.ok) { throw new Error(body); }
 
     dispatch(updateCurrentNote({ title: body.title, content: body.content }));
     dispatch(requestSuccess());
     return true;
-  } catch (errorMessage) {
-    dispatch(requestFailure(errorMessage));
+  } catch (error) {
+    dispatch(requestFailure(error.message));
     return false;
   }
 };
@@ -62,12 +62,12 @@ const destroyNote = ({ notepadId, noteId }) => async (dispatch) => {
     const response = await noteAPI.destroyNote({ notepadId, noteId });
     const body = await response.json();
 
-    if (!response.ok) { throw new Error(body.error); }
+    if (!response.ok) { throw new Error(body); }
 
     dispatch(requestSuccess());
     return true;
-  } catch (errorMessage) {
-    dispatch(requestFailure(errorMessage));
+  } catch (error) {
+    dispatch(requestFailure(error.message));
     return false;
   }
 };

--- a/src/redux/middlewares/notepadMiddlewares.jsx
+++ b/src/redux/middlewares/notepadMiddlewares.jsx
@@ -8,14 +8,14 @@ const getNotepads = () => async (dispatch) => {
     const response = await notepadAPI.getNotepads();
     const body = await response.json();
 
-    if (!response.ok) { throw new Error(body.error); }
+    if (!response.ok) { throw new Error(body); }
 
     dispatch(updateNotepadsList(body));
     dispatch(requestSuccess());
 
     return true;
-  } catch (errorMessage) {
-    dispatch(requestFailure(errorMessage));
+  } catch (error) {
+    dispatch(requestFailure(error.message));
     return false;
   }
 };
@@ -26,14 +26,14 @@ const getNotepad = ({ notepadId }) => async (dispatch) => {
     const response = await notepadAPI.getNotepad({ notepadId });
     const body = await response.json();
 
-    if (!response.ok) { throw new Error(body.error); }
+    if (!response.ok) { throw new Error(body); }
 
     dispatch(updateCurrentNotepad(body));
     dispatch(requestSuccess());
 
     return true;
-  } catch (errorMessage) {
-    dispatch(requestFailure(errorMessage));
+  } catch (error) {
+    dispatch(requestFailure(error.message));
     return false;
   }
 };
@@ -44,12 +44,12 @@ const createNotepad = ({ title, userId }) => async (dispatch) => {
     const response = await notepadAPI.createNotepad({ title, userId });
     const body = await response.json();
 
-    if (!response.ok) { throw new Error(body.error); }
+    if (!response.ok) { throw new Error(body); }
 
     dispatch(requestSuccess());
     return true;
-  } catch (errorMessage) {
-    dispatch(requestFailure(errorMessage));
+  } catch (error) {
+    dispatch(requestFailure(error.message));
     return false;
   }
 };
@@ -60,12 +60,12 @@ const updateNotepad = ({ title, notepadId }) => async (dispatch) => {
     const response = await notepadAPI.updateNotepad({ title, notepadId });
     const body = await response.json();
 
-    if (!response.ok) { throw new Error(body.error); }
+    if (!response.ok) { throw new Error(body); }
 
     dispatch(requestSuccess());
     return true;
-  } catch (errorMessage) {
-    dispatch(requestFailure(errorMessage));
+  } catch (error) {
+    dispatch(requestFailure(error.message));
     return false;
   }
 };
@@ -79,8 +79,8 @@ const destroyNotepad = ({ notepadId }) => async (dispatch) => {
 
     dispatch(requestSuccess());
     return true;
-  } catch (errorMessage) {
-    dispatch(requestFailure(errorMessage));
+  } catch (error) {
+    dispatch(requestFailure(error.message));
     return false;
   }
 };


### PR DESCRIPTION
The errors do a fail display because the Error object was sended to
reducer.
Now only #message of Error object is sended